### PR TITLE
Assign thunk to null instead of using delete

### DIFF
--- a/src/Data/Lazy.js
+++ b/src/Data/Lazy.js
@@ -16,7 +16,7 @@ exports.defer = function () {
 
   Defer.prototype.force = function () {
     var value = this.thunk();
-    delete this.thunk;
+    this.thunk = null;
     this.force = function () {
       return value;
     };


### PR DESCRIPTION
For:
```javascript
for (var i = 0; i < 1e6; ++i) {
  var x = defer(function() {
    return 1;
  });
  for (var j = 0; j < 100; ++j) {
    x.force();
    x.force();
    x.force();
    x.force();
  }
}
```
I get 16 seconds with `delete` and 9 seconds with `null`, consistently, in Chrome.