### PR TITLE
Implement without constructors (leak fixed)

### DIFF
--- a/src/Data/Lazy.js
+++ b/src/Data/Lazy.js
@@ -1,29 +1,19 @@
 "use strict";
 
-exports.defer = function () {
-
-  function Defer(thunk) {
-    if (this instanceof Defer) {
-      this.thunk = thunk;
-      return this;
+exports.defer = function (thunk) {
+  var done = false;
+  var v    = null;
+  return function() {
+    if (done) {
+      return v;
     } else {
-      return new Defer(thunk);
+      v    = thunk();
+      done = true;
+      return v;
     }
   }
-
-  Defer.prototype.force = function () {
-    var value = this.thunk();
-    this.thunk = null;
-    this.force = function () {
-      return value;
-    };
-    return value;
-  };
-
-  return Defer;
-
-}();
+};
 
 exports.force = function (l) {
-  return l.force();
+  return l();
 };

--- a/src/Data/Lazy.js
+++ b/src/Data/Lazy.js
@@ -1,16 +1,13 @@
 "use strict";
 
 exports.defer = function (thunk) {
-  var done = false;
-  var v    = null;
+  var v = null;
   return function() {
-    if (done) {
-      return v;
-    } else {
-      v    = thunk();
-      done = true;
-      return v;
-    }
+    if (thunk === undefined) return v;
+
+    v = thunk();
+    thunk = undefined;
+    return v;
   }
 };
 


### PR DESCRIPTION
This is a successor to PR #13 

By fixing a memory leak in that PR, we are able to realize a significant increase in CPU performance and decrease in memory consumption over master.

Using the benchmark of taking the length of a lazy list of 1000000 elements, in Chrome 57 on my end, time goes from ~1.55s to ~1.05s. Similarly, memory consumption drops from 274 MB to  175 MB.

Benchmarks:

Master CPU (https://github.com/matthewleon/purescript-lazy/tree/profile-0.11)
![master-cpu-profile](https://cloud.githubusercontent.com/assets/278859/24763724/22d6a26c-1aea-11e7-9286-9979d0618426.png)

Master memory (https://github.com/matthewleon/purescript-lazy/tree/profile-0.11-no-auto)
![master-mem-profile](https://cloud.githubusercontent.com/assets/278859/24763757/342b90ea-1aea-11e7-815a-0f58cc5733f6.png)

Constructorless CPU (https://github.com/matthewleon/purescript-lazy/tree/constructorless-profile-new)
![constructorless-cpu-profile](https://cloud.githubusercontent.com/assets/278859/24763802/586e1c84-1aea-11e7-8b9b-dbd14bb7affd.png)

Constructorless memory (https://github.com/matthewleon/purescript-lazy/tree/constructorless-profile-new-no-auto)
![constructorless-mem-profile](https://cloud.githubusercontent.com/assets/278859/24763809/646101b4-1aea-11e7-95b7-f9a6a5d0bad6.png)
