### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Data/Lazy.purs
+++ b/src/Data/Lazy.purs
@@ -29,6 +29,8 @@ import Data.TraversableWithIndex (class TraversableWithIndex)
 -- | `Lazy` values can be evaluated by using the `force` function.
 foreign import data Lazy :: Type -> Type
 
+type role Lazy representational
+
 -- | Defer a computation, creating a `Lazy` value.
 foreign import defer :: forall a. (Unit -> a) -> Lazy a
 


### PR DESCRIPTION
This allows terms of type `Lazy a` to be coerced to type `Lazy b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under thunks for instance.